### PR TITLE
API for adding new machine without switch

### DIFF
--- a/v2.5/src/app/controllers/modalControllers.js
+++ b/v2.5/src/app/controllers/modalControllers.js
@@ -116,17 +116,18 @@
         $scope.switchOptions = allSwitches;
         $scope.selected_switch = allSwitches[0];
 
+        $scope.cluster = wizardService.getClusterInfo();
+
         $scope.newMac = []
 
         $scope.addNewMacAddress = function() {
-          console.log("inside the function");
           return $scope.newMac.push({
             address: ''
           });
         };
 
         $scope.ok = function() {
-          return wizardService.addSingMachine($scope, $modalInstance, allMachines);
+          return wizardService.addMachineWithoutSwitch($scope, $modalInstance, allMachines);
         };
 
         return $scope.cancel = function() {

--- a/v2.5/src/app/services/dataService.js
+++ b/v2.5/src/app/services/dataService.js
@@ -184,6 +184,10 @@
         return this.$http.post(this.settings.apiUrlBase + '/switches/' + switch_id + '/machines', angular.toJson(request));
       };
 
+      DS.prototype.postNewMachineWithoutSwitch = function(request) {
+        return this.$http.post(this.settings.apiUrlBase + '/machines', angular.toJson(request));
+      };
+
       return DS;
 
     })();

--- a/v2.5/src/app/services/wizardService.js
+++ b/v2.5/src/app/services/wizardService.js
@@ -1665,6 +1665,21 @@
         });
       };
 
+      WizardService.prototype.addMachineWithoutSwitch = function($scope, $modalInstance, allMachines) {
+        var request;
+        request = {};
+        request.ipmi_credentials = {}
+        request.owner_id = $scope.cluster.id;
+        // We have a list of objects for mac addresses, but taking just first address for now
+        request.mac = $scope.newMac[0].address;
+        request.ipmi_credentials.ip = $scope.ipmi;
+        request.ipmi_credentials.pass = $scope.ipmipass;
+        return this.dataService.postNewMachineWithoutSwitch(request).success(function(data) {
+          allMachines.push(data);
+          return $modalInstance.dismiss('ok');
+        });
+      };
+
       return WizardService;
 
     })();


### PR DESCRIPTION
API for adding new machines with multiple mac address and ipmi credentials. Though the python api only takes one mac address for now, so we send only one mac address for the flask api from the view.

Business logic for #2 